### PR TITLE
Minor cleanup and nitpicks

### DIFF
--- a/site/articles/auto-diff.md
+++ b/site/articles/auto-diff.md
@@ -423,7 +423,7 @@ FuncOp partialDiff() {
 
     // Transform f to f' w.r.t ind
     AtomicBoolean first = new AtomicBoolean(true);
-    FuncOp dfcm = f.transform(STR."d\{f.funcName()}_darg\{indI}",
+    FuncOp dfcm = fcm.transform(STR."d\{fcm.funcName()}_darg\{indI}",
             (block, op) -> {
                 // Initialization
                 if (first.getAndSet(false)) {

--- a/site/articles/auto-diff.md
+++ b/site/articles/auto-diff.md
@@ -384,7 +384,7 @@ public final class ForwardDifferentiation {
     Value zero;
 
     private ForwardDifferentiation(FuncOp fcm, Block.Parameter ind) {
-        int indI = f.body().entryBlock().parameters().indexOf(ind);
+        int indI = fcm.body().entryBlock().parameters().indexOf(ind);
         if (indI == -1) {
             throw new IllegalArgumentException("Independent argument not defined by function");
         }
@@ -392,7 +392,7 @@ public final class ForwardDifferentiation {
         this.ind = ind;
 
         // Calculate the active set of dependent values for the independent value
-        this.activeSet = ActiveSet.activeSet(f, ind);
+        this.activeSet = ActiveSet.activeSet(fcm, ind);
         // A mapping of input values to their (output) differentiated values
         this.diffValueMapping = new HashMap<>();
     }


### PR DESCRIPTION
This pull request just cleans up some typos and nitpicks here and there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon-docs.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/babylon-docs.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon-docs/pull/2.diff">https://git.openjdk.org/babylon-docs/pull/2.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon-docs/pull/2#issuecomment-1925659925)