### PR TITLE
Correct note on value use and block dominance

### DIFF
--- a/site/articles/code-models.md
+++ b/site/articles/code-models.md
@@ -801,8 +801,9 @@ iteration. The (back) branch in `^block_3` passes the values to be used for the
 next loop iteration as block arguments.
 
 > A value can be used by an operation if it is defined earlier in the same
-> block or defined in a dominating block. This is why the `invoke` operation
-> in `^block_2` can use `%4`, since `^block_1` dominates `^block_2`.
+> block or defined in a dominating block. This is why the `add` operation
+> in `^block_2` or the `invoke` operation in `^block_4` can use `%4`, since 
+> `^block_1` dominates `^block_2` and `^block_4`.
 
 > Structured control flow operations and pure SSA form are not mutually
 > exclusive. Although we will not model Java expressions and statement


### PR DESCRIPTION
Correct note on value use and block dominance, reported by @rgiulietti

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon-docs.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/babylon-docs.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon-docs/pull/6.diff">https://git.openjdk.org/babylon-docs/pull/6.diff</a>

</details>
