### PR TITLE
Minor typos fixed for the Triton article

### DIFF
--- a/site/articles/triton.md
+++ b/site/articles/triton.md
@@ -17,7 +17,7 @@ understanding of Code Reflection and its capabilities.
 
 ## Triton
 
-[Triton][Triton-intro] is a domain-specific programming model and compiler
+[Triton][Triton-intro] is a domain-specific programming model that compiler
 developers can use to write programs in Python that compile to GPU code.
 
 Triton enables developers with little or no experience of GPU hardware and
@@ -50,7 +50,7 @@ size must be constant (in addition the size must be a power of two).
 
 ### Vector addition
 
-To explain the programing model we shall present a simple example, vector
+To explain the programming model we shall present a simple example, vector
 addition. This example is instructive even though it can be easily written in
 CUDA.
 
@@ -100,7 +100,7 @@ identifies it as a Triton program.
 
 This program is designed to be compiled to a GPU program and executed multiple
 times in parallel on the GPU. Each execution will have a program identifier
-associated with it, obtained by calling the Triton langauge API
+associated with it, obtained by calling the Triton language API
 method `program_id`. This is not a thread identifier, although developers
 familiar with CUDA will likely recognize that it is used in similar manner.
 
@@ -295,7 +295,7 @@ module {
 
 MLIR programs have the property of Static Single-Assignment (SSA). We refer to
 variables that can only be assigned once as values (they are a bit like final
-variables in Java) .e.g., value `%0` can never be modified.
+variables in Java) e.g., value `%0` can never be modified.
 
 Notice that there are only four parameters corresponding to values `%arg0`
 to `%arg3`: three pointers to 32-bit floats corresponding to the two input


### PR DESCRIPTION
Minor typos fixed for the Triton article

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon-docs.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/babylon-docs.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon-docs/pull/14.diff">https://git.openjdk.org/babylon-docs/pull/14.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon-docs/pull/14#issuecomment-3666034788)
</details>
