### PR TITLE
Sync docs with latest API

### DIFF
--- a/site/articles/auto-diff.md
+++ b/site/articles/auto-diff.md
@@ -186,8 +186,9 @@ declaration.
 A code model is a tree containing operations, bodies, and blocks. An operation
 contains zero or more bodies. A body contains one or more blocks. A block
 contains a sequence of one or more operations. A block can declare zero or more
-block parameters, values. An operation declares an operation result, a value. An
-operation may use values as operands, but only after they have been declared.
+block parameters, values. A non-root operation declares an operation result, a
+value. An operation may use values as operands, but only after they have been
+declared.
 
 Using this simple tree structure we can define operations that model many Java
 language constructs, and therefore we can build code models that model many Java
@@ -229,9 +230,8 @@ func @loc="79:5:file:///.../TestForwardAutoDiff.java" @"f"
 ```
 
 The textual form shows the code model's root is a function declaration (`func`)
-operation. The function declaration operation has an operation result, like all
-other operations, but since it's the root of the tree there is no need to
-present it.
+operation. Since the function declaration operation is a root it does not have
+an operation result.
 
 The lambda-like expression represents the fusion of the function declaration
 operation's single body and the body's first and only block, called the entry
@@ -244,8 +244,9 @@ and `y`), each described by a type of `java.type:"double"`, which model `f`'s
 method parameters. These parameters are used as operands of various operations.
 Many operations produce operation results, e.g., `%12` the result of a
 multiplication operation, that are used as operands of subsequent operations,
-and so on. The `return` operation has a result, again like all other operations,
-but since that result cannot be meaningfully used we don't present it.
+and so on. The `return` operation has a result, again like all other non-root
+operations, but since that result cannot be meaningfully used we don't present
+it.
 
 Code models have the property of Static Single-Assignment (SSA). We refer to
 variables that can only be assigned once as values (they are a bit like final
@@ -439,7 +440,7 @@ FuncOp partialDiff() {
                     // so that it can be used when differentiating subsequent operations
                     diffValueMapping.put(op.result(), dor);
                 } else {
-                    block.op(op);
+                    block.add(op);
                 }
                 return block;
             });
@@ -449,9 +450,9 @@ FuncOp partialDiff() {
 
 void processBlocks(Block.Builder block) {
     // Declare constants at start
-    zero = block.op(constant(ind.type(), 0.0d));
+    zero = block.add(constant(ind.type(), 0.0d));
     // The differential of ind is 1
-    Value one = block.op(constant(ind.type(), 1.0d));
+    Value one = block.add(constant(ind.type(), 1.0d));
     diffValueMapping.put(ind, one);
 
     ...
@@ -486,7 +487,7 @@ Value diffOp(Block.Builder block, Op op) {
         ...
         case JavaOp.MulOp _ -> {
             // Copy input operation
-            block.op(op);
+            block.add(op);
 
             // Product rule
             // diff(l) * r + l * diff(r)
@@ -496,13 +497,13 @@ Value diffOp(Block.Builder block, Op op) {
             Value drhs = diffValueMapping.getOrDefault(rhs, zero);
             Value outputLhs = block.context().getValue(lhs);
             Value outputRhs = block.context().getValue(rhs);
-            yield block.op(JavaOp.add(
-                    block.op(JavaOp.mul(dlhs, outputRhs)),
-                    block.op(JavaOp.mul(outputLhs, drhs))));
+            yield block.add(JavaOp.add(
+                    block.add(JavaOp.mul(dlhs, outputRhs)),
+                    block.add(JavaOp.mul(outputLhs, drhs))));
         }
         ...
         case JavaOp.InvokeOp c -> {
-            MethodRef md = c.invokeDescriptor();
+            MethodRef md = c.invokeReference();
             String operationName = null;
             if (md.refType().equals(J_L_MATH)) {
                 operationName = md.name();
@@ -510,15 +511,15 @@ Value diffOp(Block.Builder block, Op op) {
             // Differentiate sin(x)
             if ("sin".equals(operationName)) {
                 // Copy input operation
-                block.op(op);
+                block.add(op);
 
                 // Chain rule
                 // cos(expr) * diff(expr)
                 Value a = op.operands().get(0);
                 Value da = diffValueMapping.getOrDefault(a, zero);
                 Value outputA = block.context().getValue(a);
-                Result cosx = block.op(JavaOp.invoke(J_L_MATH_COS, outputA));
-                yield block.op(JavaOp.mul(cosx, da));
+                Result cosx = block.add(JavaOp.invoke(J_L_MATH_COS, outputA));
+                yield block.add(JavaOp.mul(cosx, da));
             } else {
                 throw new UnsupportedOperationException("Operation not supported: " + op);
             }

--- a/site/articles/code-models.md
+++ b/site/articles/code-models.md
@@ -80,7 +80,7 @@ that do will enjoy using code reflection).
 A code model contains code elements, operations, bodies, and blocks, that form a
 tree. An operation contains zero or more bodies. A body contains one or more
 blocks. A block contains a sequence of one or more operations. A block can
-declare zero or more block parameters, values. An operation declares an
+declare zero or more block parameters, values. A non-root operation declares an
 operation result, a value. An operation may use values as operands, but only
 after they have been declared. A value has a type.
 
@@ -279,9 +279,8 @@ and which have already seen when we printed out the classes. Unsurprisingly the
 printed operations and printed operation classes occur in the same order since
 the `toText` method traverses the model in the same order as we traversed.
 
-> The function declaration operation has an operation result, like all other
-> operations, but since it's the root of the tree and not used we don't
-> present it.
+> Since the function declaration operation is a root it does not have an
+> operation result.
 
 The entry block has two block parameters, `%0` and `%1` each described by a type
 of `java.type:"double"`, which model method `sub`'s initial values for
@@ -307,8 +306,9 @@ operations. Likewise, subsequent operations also produce results, e.g., `%6` the
 result of a subtraction operation, that is used as an operand of the
 `return` operation.
 
-> The `return` operation has a result, again like all other operations, but
-> since that result cannot be meaningfully used we don't present it by default.
+> The `return` operation has a result, again like all other non-root operations,
+> but since that result cannot be meaningfully used we don't present it by
+> default.
 
 Now let us consider a slightly more complex method, `distance1`, that computes a
 simple mathematical expression, the distance between two scalar values.
@@ -507,7 +507,7 @@ that _lowers_ such operations.
 
 [//]: # (@formatter:off)
 ```jshelllanguage
-CoreOp.FuncOp loweredModel = model.transform(OpTransformer.LOWERING_TRANSFORMER);
+CoreOp.FuncOp loweredModel = model.transform(CodeTransformer.LOWERING_TRANSFORMER);
 ```
 [//]: # (@formatter:on)
 
@@ -774,7 +774,7 @@ func @loc="71:5:file:///.../TestExpressionGraphs.java" @"distanceN"
 
 > Both the `java.for` operation and the `java.cexpression` operation
 > implement their own replacement. The corresponding operation classes
-> extend from `Op.Lowerable` interface, which declares an abstract method,
+> implement the `Op.Lowerable` interface, which declares an abstract method,
 > `lower`, that each operation implements.
 
 The `func` operation's body contains a control flow graph. Notice that
@@ -1108,8 +1108,8 @@ static Map<Value, Node<Value>> expressionGraphs(Body b) {
 ```
 
 > The switch statement is exhaustive and does not require a default clause.
-> `Body`, `Block`, and `Op` extend from the sealed abstract class
-> `CodeElement` which permits only those prior classes.
+> `Body`, `Block`, and `Op` implement the sealed interface `CodeElement` which
+> permits only those prior classes.
 
 This approach works because code elements are traversed in a specific order,
 where values are declared before they are used. Therefore, we don't need to

--- a/site/articles/linq.md
+++ b/site/articles/linq.md
@@ -168,7 +168,7 @@ customer is located in the city of London, as follows.
 ```java
 @Reflect
 Predicate<Customer> p = c -> c.city.equals("London");
-Optional<JavaOp.LambdaOp> q = Op.ofLambda(p);
+Optional<Quoted<JavaOp.LambdaOp>> q = Op.ofLambda(p);
 JavaOp.LambdaOp pcm = q.orElseThrow().op();
 ```
 [//]: # (@formatter:on)
@@ -180,18 +180,16 @@ those values from the quoted instance.
 
 The code model of `p` is represented as an instance of `JavaOp.LambdaOp`
 corresponding to a *lambda expression* operation that models a lambda
-expression. Since quoting is potentially not limited to just the quoting of
-lambda expressions we first obtain the code model as an instance
-of `java.incubator.code.Op`, the top-level type for all operations, from
-which we then down cast.
+expression.
 
 ### Explaining the code model
 
 A code model is a tree containing operations, bodies, and blocks. An operation
 contains zero or more bodies. A body contains one or more blocks. A block
 contains a sequence of one or more operations. A block can declare zero or more
-block parameters, values. An operation declares an operation result, a value. An
-operation may use values as operands, but only after they have been declared.
+block parameters, values. A non-root operation declares an operation result, a
+value. An operation may use values as operands, but only after they have been
+declared.
 
 Using this simple tree structure we can define operations that model many Java
 language constructs, and therefore we can build code models that model many Java
@@ -224,24 +222,22 @@ Which prints the following text.
 };
 ```
 
-The textual form shows the code model's root is a lambda expression (`lambda`)
-operation. The lambda expression operation has an operation result, like all
-other operations, but since it's the root of the tree there is no need to
-present it.
+The textual form shows the code model is a lambda expression (`lambda`)
+operation and its result has a type that is the lambda's functional interface.
 
 The lambda-like expression represents the fusion of the lambda expression
 operation's single body and the body's first and only block, called the entry
 block. Then there is a sequence of operations in the entry block. For each
 operation there is an instance of a corresponding class present in the in-memory
-form, all of which extend from the abstract class `java.incubator.code.Op`.
+form, all of which extend from the abstract class `jdk.incubator.code.Op`.
 
 The entry block has one block parameters, `%1` (corresponding to `c`), described
 by a type of `linq.TestLinq$Customer`, which models `p`'s parameter. This
 parameter is used as an operand of another operation. Many operations produce
 operation results, e.g., `%4` the result of a field load operation, that are
 used as operands of subsequent operations, and so on. The `return`
-operation has a result, again like all other operations, but since that result
-cannot be meaningfully used we don't present it.
+operation has a result, again like all other non-root operations, but since that
+result cannot be meaningfully used we don't present it.
 
 Code models have the property of Static Single-Assignment (SSA). We refer to
 variables that can only be assigned once as values (they are a bit like final
@@ -447,15 +443,15 @@ private Queryable<?> insertQuery(JavaType elementType, String methodName, JavaOp
     FuncOp queryExpression = expression();
     JavaType queryableType = parameterized(Queryable.TYPE, elementType);
     FuncOp nextQueryExpression = func("query",
-            functionType(queryableType, queryExpression.invokableType().parameterTypes()))
+            functionType(queryableType, queryExpression.invokableSignature().parameterTypes()))
             .body(b -> Inliner.inline(b, queryExpression, b.parameters(), (block, query) -> {
-                Result fi = block.op(lambdaOp);
+                Result fi = block.add(lambdaOp);
 
                 MethodRef md = method(Queryable.TYPE, methodName,
                         functionType(Queryable.TYPE, ((ClassType) lambdaOp.functionalInterface()).rawType()));
-                Result queryable = block.op(JavaOp.invoke(queryableType, md, query, fi));
+                Result queryable = block.add(JavaOp.invoke(queryableType, md, query, fi));
 
-                block.op(return_(queryable));
+                block.add(return_(queryable));
             }));
 
     return provider().createQuery(elementType, nextQueryExpression);

--- a/site/articles/triton.md
+++ b/site/articles/triton.md
@@ -434,8 +434,9 @@ expression `Triton.add(block_start, range)`
 A code model is a tree containing operations, bodies, and blocks. An operation
 contains zero or more bodies. A body contains one or more blocks. A block
 contains a sequence of one or more operations. A block can declare zero or more
-block parameters, values. An operation declares an operation result, a value. An
-operation may use values as operands, but only after they have been declared.
+block parameters, values. A non-root operation declares an operation result, a
+value. An operation may use values as operands, but only after they have been
+declared.
 
 Using this simple tree structure we can define operations that model many Java
 language constructs, and therefore we can build code models that model many Java
@@ -512,22 +513,21 @@ func @loc="107:5:file:/.../TestAddKernel.java" @"add_kernel2"
 ```
 
 The textual form shows the code model's root is a function declaration (`func`)
-operation. The function declaration operation has an operation result, like all
-other operations, but since it's the root of the tree there is no need to
-present it.
+operation. Since the function declaration operation is a root it does not have
+an operation result.
 
 The lambda-like expression represents the fusion of the function declaration
 operation's single body and the body's first and only block, called the entry
 block. Then there is a sequence of operations in the entry block. For each
 operation there is an instance of a corresponding class present in the in-memory
-form, all of which extend from the abstract class `java.incubator.code.Op`.
+form, all of which extend from the abstract class `jdk.incubator.code.Op`.
 
 The entry block has four block parameters which model `add_kernel2`'s method
 parameters. These parameters are used as operands of various operations. Many
 operations produce operation results, e.g., `%15` the result of a multiplication
 operation, that are used as operands of subsequent operations, and so on.
-The `return` operation has a result, again like all other operations, but since
-that result cannot be meaningfully used we don't present it.
+The `return` operation has a result, again like all other non-root operations,
+but since that result cannot be meaningfully used we don't present it.
 
 Code models have the property of Static Single-Assignment (SSA). We refer to
 variables that can only be assigned once as values (they are a bit like final
@@ -553,10 +553,13 @@ type checking and attributing richer types to all the values declared in the
 Java code model.
 
 To do this we shall traverse the code model building a map of value to computed
-type (an instance of `Map<j.l.r.code.Value, j.l.r.code.TypeElement>`), that
-represents the result of attribution after traversal is complete. In effect the
-traversal performs an _abstract interpretation_ of the code. For each operation
+type (an instance of `Map<j.i.code.Value, j.i.code.CodeType>`), that represents
+the result of attribution after traversal is complete. In effect the traversal
+performs an _abstract interpretation_ of the code. For each operation
 encountered we will perform some type-based computation based on its semantics.
+
+> For presentation purposes in the above and other examples we abbreviate the
+> package `jdk.incubator.code` to `j.i.code`. 
 
 We first have to initialize (or seed) the map with the method's parameters and
 their richer types. Here is the test method for testing the vector addition
@@ -568,7 +571,7 @@ program's parameters.
 @TritonTestExtension.Kernel("add_kernel2")
 @Test
 public void test2(TritonTestData t) {
-    List<TypeElement> argTypes = List.of(
+    List<CodeType> argTypes = List.of(
             new PtrType(JavaType.FLOAT),
             new PtrType(JavaType.FLOAT),
             new PtrType(JavaType.FLOAT),
@@ -592,11 +595,10 @@ the (Python) Triton compiler. We have:
   of `Tensor`.
 
 These classes model Triton types, instances are Triton code model types
-extending from `TritonType` which in turn extends from `j.l.r.code.TypeElement`.
-The class `JavaType` models Java types, and similarly extends
-from `j.l.r.code.TypeElement`. Therefore, we can use pattern matching to operate
-on specific kinds of code model types, or alternatively we can uniformly operate
-on all code model types.
+extending from `TritonType` which in turn implements `j.i.code.CodeType`. The
+interface `JavaType` models Java types, and extends from `j.i.code.CodeType`.
+Therefore, we can use pattern matching to operate on specific kinds of code
+model types, or alternatively we can uniformly operate on all code model types.
 
 Triton types are not Java types i.e., they cannot be declared in Java programs
 as the types of variables. However, notice that Triton types can conveniently
@@ -726,7 +728,7 @@ Here's the builder implementation for the `Triton.arange` method:
 public Value arange(TensorType rType, Op.Result r,
                     ConstantType startType, Value start,
                     ConstantType endType, Value end) {
-    return block.op(TritonOps.makeRange(
+    return block.add(TritonOps.makeRange(
             (int) startType.value(),
             (int) endType.value()));
 }
@@ -735,7 +737,7 @@ public Value arange(TensorType rType, Op.Result r,
 We use the output block builder, `block`, to replace the invocation to
 `Triton.arange` with the Triton make range operation, whose result type is the
 same as `rType`. Note in this case we don't use `rType`, since the operation
-reconstructs an equivalent instance. Instances of `TypeElement` are value-based,
+reconstructs an equivalent instance. Instances of `CodeType` are value-based,
 so we could assert such equality e.g.,
 
 [//]: # (@formatter:off)
@@ -752,7 +754,7 @@ public Value load(TensorType rType, Op.Result r,
                   TensorType ptrType, Value ptr,
                   TensorType maskType, Value mask) {
     broadcastConversionRight(ptrType, maskType, mask);
-    return block.op(TritonOps.load(
+    return block.add(TritonOps.load(
             rType,
             block.context().getValue(ptr),
             block.context().getValue(mask)));


### PR DESCRIPTION
Sync docs with latest API.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon-docs.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/babylon-docs.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon-docs/pull/21.diff">https://git.openjdk.org/babylon-docs/pull/21.diff</a>

</details>
